### PR TITLE
decode_glo_str bugfix

### DIFF
--- a/src/sdr_nav.c
+++ b/src/sdr_nav.c
@@ -648,7 +648,7 @@ static void decode_glo_str(sdr_ch_t *ch, const uint8_t *syms, int rev)
     }
     sdr_pack_bits(bits, 85, 0, data); // GLONASS string (85 bits, packed)
     
-    if (test_glostr(bits)) {
+    if (test_glostr(data)) {
         ch->nav->fsync = ch->lock;
         ch->nav->rev = rev;
         memcpy(ch->nav->data, data, 11);


### PR DESCRIPTION
Without fix, the Hamming code is calculated for the first eight bits of the GLONASS string.