### PR TITLE
File format conversion fixed

### DIFF
--- a/python/pocket_sdr.py
+++ b/python/pocket_sdr.py
@@ -122,7 +122,7 @@ def rcv_open_dev(sys_opt, inp_opt, out_opt, sig_opt):
 # start receiver by file -------------------------------------------------------
 def rcv_open_file(sys_opt, inp_opt, out_opt, sig_opt):
     sigs, prns = get_sig_opt(sig_opt)
-    fmt = inp_opt.fmts.index(inp_opt.fmt.get())
+    fmt = inp_opt.fmts.index(inp_opt.fmt.get()) + 1
     fs = to_float(inp_opt.fs.get()) * 1e6
     fo = [to_float(inp_opt.fo[i].get()) * 1e6 for i in range(4)]
     IQ = [1 if inp_opt.IQ[i].get() == 'I' else 2 for i in range(4)]


### PR DESCRIPTION
Position returned by index() method starts from 0. But in C-code the file format is encoded starting from one. The problem appears only in case of opening a file without corresponding tag file.